### PR TITLE
add type module to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "bun-plugin-dts",
   "version": "0.2.1",
   "main": "dist/index.js",
+  "type": "module",
   "types": "dist/index.d.ts",
   "description": "A bun plugin for generating dts files",
   "scripts": {


### PR DESCRIPTION
When using this package via bun+ts (eg: build.ts) the package is assumed to be a `commonjs` module by TS and the types are parsed wrong exporting an object like:
```ts
export default {
  default: (options?: Options) => import("bun").BunPlugin;
}
```
instead of:
```ts
export default (options?: Options) => import("bun").BunPlugin
```
![image](https://github.com/wobsoriano/bun-plugin-dts/assets/22945955/0e5d70a8-47dc-4902-89e7-92fa24eb4924)

At runtime the package still works, but at "dev-time" the error persists.
With the addition of `type: module` to the package.json the package is assumed correctly and there is no errors